### PR TITLE
Refactor scan/fix components into modular registries

### DIFF
--- a/FixChain/modules/__init__.py
+++ b/FixChain/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules package."""

--- a/FixChain/modules/fix/__init__.py
+++ b/FixChain/modules/fix/__init__.py
@@ -1,0 +1,6 @@
+from .registry import register, create
+
+# Ensure fixers are registered when package is imported
+from . import fixer  # noqa: F401
+
+__all__ = ["register", "create"]

--- a/FixChain/modules/fix/base.py
+++ b/FixChain/modules/fix/base.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Dict, List
+
+
+class Fixer:
+    """Base fixer interface"""
+
+    def fix_bugs(self, list_real_bugs: List[Dict], use_rag: bool = False) -> Dict:
+        """Apply fixes to provided bugs"""
+        raise NotImplementedError

--- a/FixChain/modules/fix/fixer.py
+++ b/FixChain/modules/fix/fixer.py
@@ -4,10 +4,13 @@ import os
 from typing import Dict, List
 
 from utils.logger import logger
-from .cli_service import CLIService
+from service.cli_service import CLIService
+
+from .base import Fixer
+from .registry import register
 
 
-class Fixer:
+class BatchFixer(Fixer):
     """Service that applies fixes using batch_fix.py"""
 
     def __init__(self, scan_directory: str):
@@ -140,3 +143,6 @@ class Fixer:
                 "fixed_count": 0,
                 "error": str(e),
             }
+
+
+register("batch", BatchFixer)

--- a/FixChain/modules/fix/registry.py
+++ b/FixChain/modules/fix/registry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Dict, Type
+
+from .base import Fixer
+
+_registry: Dict[str, Type[Fixer]] = {}
+
+
+def register(name: str, cls: Type[Fixer]) -> None:
+    """Register a fixer class"""
+    _registry[name] = cls
+
+
+def create(name: str, *args, **kwargs) -> Fixer:
+    """Create a fixer instance by name"""
+    if name not in _registry:
+        raise ValueError(f"Fixer '{name}' is not registered")
+    return _registry[name](*args, **kwargs)

--- a/FixChain/modules/rag/__init__.py
+++ b/FixChain/modules/rag/__init__.py
@@ -1,0 +1,3 @@
+from .registry import register, create
+
+__all__ = ["register", "create"]

--- a/FixChain/modules/rag/base.py
+++ b/FixChain/modules/rag/base.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class RAG:
+    """Base RAG interface"""
+
+    def run(self, *args, **kwargs):
+        """Execute RAG operation"""
+        raise NotImplementedError

--- a/FixChain/modules/rag/registry.py
+++ b/FixChain/modules/rag/registry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Dict, Type
+
+from .base import RAG
+
+_registry: Dict[str, Type[RAG]] = {}
+
+
+def register(name: str, cls: Type[RAG]) -> None:
+    """Register a RAG class"""
+    _registry[name] = cls
+
+
+def create(name: str, *args, **kwargs) -> RAG:
+    """Create a RAG instance by name"""
+    if name not in _registry:
+        raise ValueError(f"RAG '{name}' is not registered")
+    return _registry[name](*args, **kwargs)

--- a/FixChain/modules/scan/__init__.py
+++ b/FixChain/modules/scan/__init__.py
@@ -1,0 +1,7 @@
+from .registry import register, create
+
+# Ensure scanners are registered when package is imported
+from . import bearer  # noqa: F401
+from . import sonar  # noqa: F401
+
+__all__ = ["register", "create"]

--- a/FixChain/modules/scan/base.py
+++ b/FixChain/modules/scan/base.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from typing import Dict, List
+
+
+class Scanner:
+    """Base scanner interface"""
+
+    def scan(self) -> List[Dict]:
+        """Run scan and return list of bugs"""
+        raise NotImplementedError

--- a/FixChain/modules/scan/bearer.py
+++ b/FixChain/modules/scan/bearer.py
@@ -1,20 +1,13 @@
 from __future__ import annotations
 import json
 import os
-import time
 from datetime import datetime
 from typing import Dict, List
 
 from utils.logger import logger
-from .cli_service import CLIService
 
-
-class Scanner:
-    """Base scanner interface"""
-
-    def scan(self) -> List[Dict]:
-        """Run scan and return list of bugs"""
-        raise NotImplementedError
+from .base import Scanner
+from .registry import register
 
 
 class BearerScanner(Scanner):
@@ -146,113 +139,4 @@ class BearerScanner(Scanner):
         return severity_map.get(bearer_severity.upper(), "MAJOR")
 
 
-class SonarQScanner(Scanner):
-    """Scanner for SonarQube projects"""
-
-    def __init__(self, project_key: str, scan_directory: str, sonar_token: str):
-        self.project_key = project_key
-        self.scan_directory = scan_directory
-        self.sonar_token = sonar_token
-
-    def scan(self) -> List[Dict]:
-        try:
-            logger.info(
-                f"Starting SonarQube scan for project: {self.project_key}"
-            )
-            logger.info("Step 1: Running SonarQube scan...")
-            original_dir = os.getcwd()
-            innolab_root = os.getenv("INNOLAB_ROOT_PATH", "d:\\InnoLab")
-            sonar_dir = os.path.join(innolab_root, "SonarQ")
-            os.chdir(sonar_dir)
-            try:
-                logger.info(
-                    "Ensuring sonar-scanner container is running..."
-                )
-                start_cmd = (
-                    "docker start sonar_scanner 2>nul || docker-compose --profile tools up -d sonar-scanner"
-                )
-                CLIService.run_command(start_cmd, shell=True)
-                time.sleep(2)
-                if os.path.isabs(self.scan_directory):
-                    project_dir = self.scan_directory
-                else:
-                    project_dir = os.path.abspath(
-                        os.path.join(sonar_dir, self.scan_directory)
-                    )
-                logger.info(f"Project directory: {project_dir}")
-                props_file = os.path.join(project_dir, "sonar-project.properties")
-                with open(props_file, "w", encoding="utf-8") as f:
-                    f.write(f"sonar.projectKey={self.project_key}\n")
-                    f.write(f"sonar.projectName={self.project_key}\n")
-                    f.write("sonar.sources=.\n")
-                    f.write(
-                        "sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.git/**\n"
-                    )
-                logger.info(
-                    f"Created sonar-project.properties for project: {self.project_key}"
-                )
-                container_work_dir = "/usr/src"
-                scan_cmd = [
-                    "docker",
-                    "exec",
-                    "-w",
-                    container_work_dir,
-                    "-e",
-                    "SONAR_HOST_URL=http://sonarqube:9000",
-                    "-e",
-                    f"SONAR_TOKEN={self.sonar_token}",
-                    "sonar_scanner",
-                    "sonar-scanner",
-                ]
-                logger.info(
-                    f"Running containerized scan: {' '.join(scan_cmd)}"
-                )
-                success, output_lines = CLIService.run_command_stream(scan_cmd)
-                if not success:
-                    logger.error(
-                        f"SonarQube scan failed. Output: {''.join(output_lines)}"
-                    )
-                    return []
-                logger.info("SonarQube scan completed successfully")
-                logger.info("Waiting for SonarQube to process results...")
-                time.sleep(3)
-                logger.info("Step 2: Exporting issues...")
-                output_file = os.path.join(sonar_dir, f"issues_{self.project_key}.json")
-                export_cmd = [
-                    "python",
-                    os.path.join(sonar_dir, "export_to_file.py"),
-                    self.project_key,
-                    output_file,
-                ]
-                if not CLIService.run_command(export_cmd, cwd=sonar_dir):
-                    logger.error("Issues export failed")
-                    return []
-                if os.path.exists(output_file):
-                    with open(output_file, "r", encoding="utf-8") as f:
-                        bugs_data = json.load(f)
-                    all_bugs = bugs_data.get("issues", [])
-                    open_bugs = [
-                        bug
-                        for bug in all_bugs
-                        if bug.get("status", "").upper() == "OPEN"
-                    ]
-                    closed_bugs = [
-                        bug
-                        for bug in all_bugs
-                        if bug.get("status", "").upper() != "OPEN"
-                    ]
-                    logger.info(
-                        f"Found {len(all_bugs)} total bugs: {len(open_bugs)} open, {len(closed_bugs)} closed/resolved"
-                    )
-                    logger.info(
-                        f"Returning {len(open_bugs)} open bugs for processing"
-                    )
-                    return open_bugs
-                else:
-                    logger.error(f"Output file not found: {output_file}")
-                    return []
-            finally:
-                os.chdir(original_dir)
-        except Exception as e:
-            logger.error(f"Error in SonarQube scan process: {str(e)}")
-            return []
+register("bearer", BearerScanner)

--- a/FixChain/modules/scan/registry.py
+++ b/FixChain/modules/scan/registry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from typing import Dict, Type
+
+from .base import Scanner
+
+_registry: Dict[str, Type[Scanner]] = {}
+
+
+def register(name: str, cls: Type[Scanner]) -> None:
+    """Register a scanner class"""
+    _registry[name] = cls
+
+
+def create(name: str, *args, **kwargs) -> Scanner:
+    """Create a scanner instance by name"""
+    if name not in _registry:
+        raise ValueError(f"Scanner '{name}' is not registered")
+    return _registry[name](*args, **kwargs)

--- a/FixChain/modules/scan/sonar.py
+++ b/FixChain/modules/scan/sonar.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+import json
+import os
+import time
+from typing import Dict, List
+
+from utils.logger import logger
+from service.cli_service import CLIService
+
+from .base import Scanner
+from .registry import register
+
+
+class SonarQScanner(Scanner):
+    """Scanner for SonarQube projects"""
+
+    def __init__(self, project_key: str, scan_directory: str, sonar_token: str):
+        self.project_key = project_key
+        self.scan_directory = scan_directory
+        self.sonar_token = sonar_token
+
+    def scan(self) -> List[Dict]:
+        try:
+            logger.info(
+                f"Starting SonarQube scan for project: {self.project_key}"
+            )
+            logger.info("Step 1: Running SonarQube scan...")
+            original_dir = os.getcwd()
+            innolab_root = os.getenv("INNOLAB_ROOT_PATH", "d:\\InnoLab")
+            sonar_dir = os.path.join(innolab_root, "SonarQ")
+            os.chdir(sonar_dir)
+            try:
+                logger.info(
+                    "Ensuring sonar-scanner container is running..."
+                )
+                start_cmd = (
+                    "docker start sonar_scanner 2>nul || docker-compose --profile tools up -d sonar-scanner"
+                )
+                CLIService.run_command(start_cmd, shell=True)
+                time.sleep(2)
+                if os.path.isabs(self.scan_directory):
+                    project_dir = self.scan_directory
+                else:
+                    project_dir = os.path.abspath(
+                        os.path.join(sonar_dir, self.scan_directory)
+                    )
+                logger.info(f"Project directory: {project_dir}")
+                props_file = os.path.join(project_dir, "sonar-project.properties")
+                with open(props_file, "w", encoding="utf-8") as f:
+                    f.write(f"sonar.projectKey={self.project_key}\n")
+                    f.write(f"sonar.projectName={self.project_key}\n")
+                    f.write("sonar.sources=.\n")
+                    f.write(
+                        "sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/.git/**\n"
+                    )
+                logger.info(
+                    f"Created sonar-project.properties for project: {self.project_key}"
+                )
+                container_work_dir = "/usr/src"
+                scan_cmd = [
+                    "docker",
+                    "exec",
+                    "-w",
+                    container_work_dir,
+                    "-e",
+                    "SONAR_HOST_URL=http://sonarqube:9000",
+                    "-e",
+                    f"SONAR_TOKEN={self.sonar_token}",
+                    "sonar_scanner",
+                    "sonar-scanner",
+                ]
+                logger.info(
+                    f"Running containerized scan: {' '.join(scan_cmd)}"
+                )
+                success, output_lines = CLIService.run_command_stream(scan_cmd)
+                if not success:
+                    logger.error(
+                        f"SonarQube scan failed. Output: {''.join(output_lines)}"
+                    )
+                    return []
+                logger.info("SonarQube scan completed successfully")
+                logger.info("Waiting for SonarQube to process results...")
+                time.sleep(3)
+                logger.info("Step 2: Exporting issues...")
+                output_file = os.path.join(sonar_dir, f"issues_{self.project_key}.json")
+                export_cmd = [
+                    "python",
+                    os.path.join(sonar_dir, "export_to_file.py"),
+                    self.project_key,
+                    output_file,
+                ]
+                if not CLIService.run_command(export_cmd, cwd=sonar_dir):
+                    logger.error("Issues export failed")
+                    return []
+                if os.path.exists(output_file):
+                    with open(output_file, "r", encoding="utf-8") as f:
+                        bugs_data = json.load(f)
+                    all_bugs = bugs_data.get("issues", [])
+                    open_bugs = [
+                        bug
+                        for bug in all_bugs
+                        if bug.get("status", "").upper() == "OPEN"
+                    ]
+                    closed_bugs = [
+                        bug
+                        for bug in all_bugs
+                        if bug.get("status", "").upper() != "OPEN"
+                    ]
+                    logger.info(
+                        f"Found {len(all_bugs)} total bugs: {len(open_bugs)} open, {len(closed_bugs)} closed/resolved"
+                    )
+                    logger.info(
+                        f"Returning {len(open_bugs)} open bugs for processing"
+                    )
+                    return open_bugs
+                else:
+                    logger.error(f"Output file not found: {output_file}")
+                    return []
+            finally:
+                os.chdir(original_dir)
+        except Exception as e:
+            logger.error(f"Error in SonarQube scan process: {str(e)}")
+            return []
+
+
+register("sonar", SonarQScanner)

--- a/FixChain/run/run_demo.py
+++ b/FixChain/run/run_demo.py
@@ -17,8 +17,8 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from lib.dify_lib import DifyMode
 from utils.logger import logger
-from service.scanner_service import BearerScanner, SonarQScanner
-from service.fix_service import Fixer
+from modules.scan.registry import create as create_scanner
+from modules.fix.registry import create as create_fixer
 from service.analysis_service import AnalysisService
 
 try:
@@ -71,12 +71,12 @@ class ExecutionServiceNoMongo:
             self.dify_cloud_api_key, self.dify_local_api_key
         )
         if self.scan_mode == 'bearer':
-            self.scanner = BearerScanner(self.project_key)
+            self.scanner = create_scanner("bearer", self.project_key)
         else:
-            self.scanner = SonarQScanner(
-                self.project_key, self.scan_directory, self.sonar_token
+            self.scanner = create_scanner(
+                "sonar", self.project_key, self.scan_directory, self.sonar_token
             )
-        self.fixer = Fixer(self.scan_directory)
+        self.fixer = create_fixer("batch", self.scan_directory)
     
     def insert_rag_default(self) -> bool:
         """Insert default RAG data for bug fixing"""


### PR DESCRIPTION
## Summary
- Add modular architecture under `modules` for scan, fix, and rag components
- Move `BearerScanner`, `SonarQScanner`, and `Fixer` into their respective modules and register them
- Update demo runner to construct scanners and fixers via registries

## Testing
- `python -m py_compile FixChain/run/run_demo.py FixChain/modules/scan/base.py FixChain/modules/scan/registry.py FixChain/modules/scan/bearer.py FixChain/modules/scan/sonar.py FixChain/modules/fix/base.py FixChain/modules/fix/registry.py FixChain/modules/fix/fixer.py FixChain/modules/rag/base.py FixChain/modules/rag/registry.py`

------
https://chatgpt.com/codex/tasks/task_b_68ac1f40f1d4832a82899e34622c182f